### PR TITLE
Add a seperate config.js file for API key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .env
+config.js

--- a/config.js
+++ b/config.js
@@ -1,9 +1,0 @@
-/*
-	API key not to be commited to version control.
-	The following command may help, but is case by case per repo.
-	>  git update-index --assume-unchanged config.js
-*/
-
-var configObj = {
-	apiKey: '<YOUR_KEY_HERE>'
-};

--- a/config.js
+++ b/config.js
@@ -1,0 +1,9 @@
+/*
+	API key not to be commited to version control.
+	The following command may help, but is case by case per repo.
+	>  git update-index --assume-unchanged config.js
+*/
+
+var configObj = {
+	apiKey: '<YOUR_KEY_HERE>'
+};

--- a/index.html
+++ b/index.html
@@ -45,6 +45,7 @@
 	
 	<script type="text/javascript" src="node_modules/jquery/dist/jquery.js"></script>
 	<script type="text/javascript" src="https://dme0ih8comzn4.cloudfront.net/imaging/v3/editor.js"></script>
+	<script type="text/javascript" src="config.js"></script>
 	<script type="text/javascript" src="index.js"></script>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ $(document).ready(function() {
 
 	// Image Editor configuration
 	var csdkImageEditor = new Aviary.Feather({
-		apiKey: '<YOUR_KEY_HERE>',
+		apiKey: configObj.apiKey,
 		onSave: function(imageID, newURL) {
 			currentImage.src = newURL;
 			csdkImageEditor.close();

--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,8 @@ Just follow the steps below.
 
 1. `git clone` this repo and `cd` into it
 1. Run `npm install` (for Bootstrap and jQuery)
-1. Add your Client ID as a string in `config.js` (replacing the string `"<YOUR_KEY_HERE>"`)
+1. Create a file called `config.js` with the following code:```var configObj = { apiKey: '<YOUR_KEY_HERE>' };```
+1. Add your Client ID as a string in config.js (replacing the string `"<YOUR_KEY_HERE>"`) 
 1. Run the app
 
 <a name="contributing"></a>

--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,7 @@ Just follow the steps below.
 
 1. `git clone` this repo and `cd` into it
 1. Run `npm install` (for Bootstrap and jQuery)
-1. Add your Client ID as a string in `index.js` (replacing the string `"<YOUR_KEY_HERE>"`)
+1. Add your Client ID as a string in `config.js` (replacing the string `"<YOUR_KEY_HERE>"`)
 1. Run the app
 
 <a name="contributing"></a>


### PR DESCRIPTION
- API key can still be accidentally committed to repo.
- Adding config.js to .gitignore will not prevent tracking, once file is
  in the repo.

In some ways an incomplete solution. I did some reading and went with the solution here:
http://stackoverflow.com/questions/26854559/add-a-file-to-a-git-repository-but-ignore-future-changes-on-it
Still, separating the key makes it easier to not commit by mistake as it is removed from the index.js file.
